### PR TITLE
closes #1 convert snake-case to CamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,33 @@ Or install it yourself as:
 
 ## Usage
 
+Note that the collectd-dsl converts snake-case to CamelCase
+
 ```ruby
 config = Collectd::DSL.parse do
-  LoadPlugin :redis
-  LoadPlugin :java
-  LoadPlugin :disk
+  load_plugin :redis
+  load_plugin :java
+  load_plugin :disk
   
-  Plugin :disk do
-    Disk "/dev/sda"
-	Disk "/dev/sdb"
-	IgnoreSelected "false"
+  plugin :disk do
+    disk "/dev/sda"
+	disk "/dev/sdb"
+	ignore_selected "false"
   end
 end
+
+```
+
+The following will be output
+```
+LoadPlugin redis
+LoadPlugin java
+LoadPlugin disk
+<Plugin disk>
+	Disk "/dev/sda"
+	Disk "/dev/sdb"
+	IgnoreSelected "false"
+</Plugin>
 
 ```
 

--- a/lib/collectd-dsl.rb
+++ b/lib/collectd-dsl.rb
@@ -20,18 +20,30 @@ module Collectd
       ("\t" * @indent) + str
     end
 
+    def snake_to_camel method_name
+      method_name.split("_").map{|w| w.capitalize }.join("")
+    end
+
     def method_missing method_name, *args
-      mapped_args = args.map{|a| a.to_s}.join(" ")
+      mapped_args = args.map do |a|
+        if a.class == String 
+          "\"" + a.to_s + "\""
+        else
+          a.to_s
+        end
+      end.join(" ")
+        
       mapped_args = (" " + mapped_args) unless mapped_args.empty?
 
+      camel_method_name = snake_to_camel method_name.to_s
       if block_given?
-        @directives << indent("<#{method_name.to_s}#{mapped_args}>")
+         @directives << indent("<#{camel_method_name}#{mapped_args}>")
         @indent += 1
         yield # rely on the outer scope
         @indent -= 1
-        @directives << indent("</#{method_name.to_s}>")
+        @directives << indent("</#{camel_method_name}>")
       else
-        @directives << indent("#{method_name.to_s}#{mapped_args}")
+        @directives << indent("#{camel_method_name}#{mapped_args}")
       end
     end
   end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -4,35 +4,35 @@ describe Collectd::DSL do
   context "simple options" do
     it "no args given" do
       config = Collectd::DSL.parse do
-        LoadPlugin :disk
+        load_plugin :disk
       end
       config.should == "LoadPlugin disk\n"
     end
     it "one arg given" do
       config = Collectd::DSL.parse do
-        LoadPlugin :disk, '/dev/sda'
+        load_plugin :disk, '/dev/sda'
       end
-      config.should == "LoadPlugin disk /dev/sda\n"
+      config.should == "LoadPlugin disk \"/dev/sda\"\n"
     end
     it "section" do
       config = Collectd::DSL.parse do
-        Plugin :disk do
-          Disk '/dev/sda'
+        plugin :disk do
+          disk '/dev/sda'
         end
       end
-      config.should == "<Plugin disk>\n\tDisk /dev/sda\n</Plugin>\n"
+      config.should == "<Plugin disk>\n\tDisk \"/dev/sda\"\n</Plugin>\n"
     end
     it "section with no args" do
       config = Collectd::DSL.parse do
-        Plugin do
-          Disk '/dev/sda'
+        plugin do
+          disk '/dev/sda'
         end
       end
-      config.should == "<Plugin>\n\tDisk /dev/sda\n</Plugin>\n"
+      config.should == "<Plugin>\n\tDisk \"/dev/sda\"\n</Plugin>\n"
     end
     it "empty section" do
       config = Collectd::DSL.parse do
-        Plugin do
+        plugin do
         end
       end
       config.should == "<Plugin>\n</Plugin>\n"


### PR DESCRIPTION
let' use snake-case for the DSL as it is the Ruby
convention, but convert the output to CamelCase
per collectd configuration format. also puts quotes
around strings but not booleans.
