### PR TITLE
implement arrays

### DIFF
--- a/lib/collectd-dsl.rb
+++ b/lib/collectd-dsl.rb
@@ -24,13 +24,25 @@ module Collectd
       method_name.split("_").map{|w| w.capitalize }.join("")
     end
 
-    def method_missing method_name, *args
-      mapped_args = args.map do |a|
-        if a.class == String 
+    def array_to_string(*args)
+      args.map do |a|
+        if a.class == String
           "\"" + a.to_s + "\""
+        elsif a.class == Array
+          r = []
+          a.each do |v|
+            r.push(array_to_string(v))
+          end
+          r.join(" ")
         else
           a.to_s
         end
+      end.join(" ")
+    end
+
+    def method_missing method_name, *args
+      mapped_args = args.map do |a|
+        array_to_string(a)
       end.join(" ")
         
       mapped_args = (" " + mapped_args) unless mapped_args.empty?

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -38,5 +38,13 @@ describe Collectd::DSL do
       config.should == "<Plugin>\n</Plugin>\n"
 
     end
+    it "arrays" do
+      config = Collectd::DSL.parse do
+        plugin do
+          driver_option ["port", 1234]
+        end
+      end
+      config.should == "<Plugin>\n\tDriverOption \"port\" 1234\n</Plugin>\n"
+    end
   end
 end


### PR DESCRIPTION
This makes it possible to allow for complex configs like for the "dbi"
plugin:
- dsl

``` ruby
Collectd::DSL.parse do
  database :processlist do
    driver "mysql"
    driver_option ["host", "mysql.at.mygtld"]
    driver_option ["username", "user"]
    driver_option ["password", "pass"]
    driver_option ["port", 1234]
    query "somequery"
  end
end
```
- collectd config

``` xml
<Plugin dbi>
  <Database "processlist">
     Driver "mysql"
     DriverOption "host" "mysql.at.mygtld"
     DriverOption "username" "user"
     DriverOption "password" "pass"
     DriverOption "port" 1234
     Query "somequery"
  </Database>
</Plugin>
```
- notes

This was formerly partly possible using:

``` ruby
Collectd::DSL.parse do
  database :processlist do
    driver "mysql"
    driver_option "host\" \"mysql.at.mygtld"
    driver_option "username\" \"user"
    driver_option "password\" \"pass"
    driver_option "port\" \"1234"
    query "somequery"
  end
end
```

But that was hackish (still supported) but didn't allow for mixed types
as is required by mysql driver option port (which needs to be numeric).
As you may know using `DriverOption "port" "1234"` will silently fail!
